### PR TITLE
feat: copy button on source input + show app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ versioned packages, releases are dated (`YYYY.M.D`).
   dispatch (`.github/workflows/deploy.yml`).
 - **Traditional Chinese (`zh-TW`)** translation, bringing the interface to
   26 languages.
+- **Copy button for the source input**, in addition to the output.
+- The **app version** is now shown in the footer.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This tool also supports decoding of `.b64` files into their original binary form
 - **Base64 Encode/Decode**: Convert plain text to Base64 and vice versa.  
 - **File Upload**: Upload files to encode or `.b64` files to decode.
 - **Download Results**: Download the converted content as `.b64`, `.bin`, or `.txt`.  
-- **Copy to Clipboard**: Copy the output with a single click.  
+- **Copy to Clipboard**: Copy the input or output with a single click.  
 - **Live Counts**: See character and UTF-8 byte counts as you type.  
 - **26 Languages**: Switch the interface language on the fly (with right-to-left support).  
 - **Dark Mode**: Toggle between light and dark themes.  

--- a/src/App.css
+++ b/src/App.css
@@ -229,7 +229,8 @@ footer a.link {
   font-family: monospace;
 }
 
-/* Output area with an overlaid copy button */
+/* Input/output areas with an overlaid copy button */
+.input-row,
 .output-row {
   position: relative;
 }
@@ -247,4 +248,12 @@ footer a.link {
 .copy-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* App version tag in the footer */
+.app-version {
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  opacity: 0.6;
+  font-family: monospace;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import {
   arrayBufferToBase64,
 } from './functions';
 import { t, isRTL, getLanguageOptions, resolveInitialLang } from './lang';
+import pkg from '../package.json';
 import './App.css';
 
 const LANGUAGE_OPTIONS = getLanguageOptions();
@@ -15,7 +16,7 @@ const byteLength = (text) => new TextEncoder().encode(text).length;
 export default function App() {
   const [input, setInput] = useState('');
   const [output, setOutput] = useState('');
-  const [copied, setCopied] = useState(false);
+  const [copiedField, setCopiedField] = useState(null);
   const [darkMode, setDarkMode] = useState(() => {
     const saved = localStorage.getItem('darkMode');
     return saved === 'true';
@@ -174,23 +175,25 @@ export default function App() {
     setDarkMode(!darkMode);
   };
 
-  const handleCopy = async () => {
-    if (!output) return;
+  const copyToClipboard = async (text, field) => {
+    if (!text) return;
     try {
       if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(output);
+        await navigator.clipboard.writeText(text);
       }
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      setCopiedField(field);
+      setTimeout(() => {
+        setCopiedField((current) => (current === field ? null : current));
+      }, 1500);
     } catch {
-      setCopied(false);
+      setCopiedField(null);
     }
   };
 
   const clearFields = () => {
     setInput('');
     setOutput('');
-    setCopied(false);
+    setCopiedField(null);
     binaryOutputRef.current = null;
     outputTypeRef.current = null;
   };
@@ -240,14 +243,28 @@ export default function App() {
           <button onClick={clearFields}>🧹 {tr('clear')}</button>
         </div>
 
-        <textarea
-          className={`textarea ${darkMode ? 'dark' : 'light'}`}
-          placeholder={tr('inputPlaceholder')}
-          aria-label={tr('inputLabel')}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleInputKeyDown}
-        />
+        <div className='input-row'>
+          <textarea
+            className={`textarea ${darkMode ? 'dark' : 'light'}`}
+            placeholder={tr('inputPlaceholder')}
+            aria-label={tr('inputLabel')}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleInputKeyDown}
+          />
+          <button
+            className='copy-button'
+            aria-label={
+              copiedField === 'input'
+                ? tr('copied')
+                : `${tr('copy')} ${tr('inputLabel')}`
+            }
+            onClick={() => copyToClipboard(input, 'input')}
+            disabled={!input}
+          >
+            📋 {copiedField === 'input' ? tr('copied') : tr('copy')}
+          </button>
+        </div>
         <div className='counts' data-testid='input-count'>
           {input.length} {tr('characters')} · {byteLength(input)} {tr('bytes')}
         </div>
@@ -262,10 +279,15 @@ export default function App() {
           />
           <button
             className='copy-button'
-            onClick={handleCopy}
+            aria-label={
+              copiedField === 'output'
+                ? tr('copied')
+                : `${tr('copy')} ${tr('outputLabel')}`
+            }
+            onClick={() => copyToClipboard(output, 'output')}
             disabled={!output}
           >
-            📋 {copied ? tr('copied') : tr('copy')}
+            📋 {copiedField === 'output' ? tr('copied') : tr('copy')}
           </button>
         </div>
         <div className='counts' data-testid='output-count'>
@@ -324,6 +346,9 @@ export default function App() {
           >
             Base64 Encoder/Decoder
           </a>
+        </p>
+        <p className='app-version' data-testid='app-version'>
+          v{pkg.version}
         </p>
       </footer>
     </div>

--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -36,6 +36,11 @@ describe('App rendering', () => {
     expect(screen.getByRole('textbox', { name: 'Input' })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Output' })).toBeInTheDocument();
   });
+
+  it('shows the app version', () => {
+    render(<App />);
+    expect(screen.getByTestId('app-version').textContent).toMatch(/^v\d/);
+  });
 });
 
 describe('Encoding and decoding', () => {
@@ -133,9 +138,10 @@ describe('Internationalization', () => {
 });
 
 describe('Copy to clipboard', () => {
-  it('is disabled when there is no output', () => {
+  it('disables both copy buttons when the fields are empty', () => {
     render(<App />);
-    expect(screen.getByRole('button', { name: /Copy/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Copy Input' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Copy Output' })).toBeDisabled();
   });
 
   it('copies the output and shows confirmation', async () => {
@@ -149,8 +155,25 @@ describe('Copy to clipboard', () => {
       target: { value: 'abc' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Encode/ }));
-    fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Output' }));
     expect(writeText).toHaveBeenCalledWith('YWJj');
+    expect(
+      await screen.findByRole('button', { name: /Copied/ })
+    ).toBeInTheDocument();
+  });
+
+  it('copies the source input text', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText(INPUT), {
+      target: { value: 'hello source' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Input' }));
+    expect(writeText).toHaveBeenCalledWith('hello source');
     expect(
       await screen.findByRole('button', { name: /Copied/ })
     ).toBeInTheDocument();


### PR DESCRIPTION
- Add a Copy button to the source (input) textarea; track copied field per area

- Show the date-based app version in the footer (from package.json)

- Distinguish copy buttons via aria-labels (Copy Input / Copy Output)

- Update tests (61 tests) and docs (README feature, CHANGELOG)

